### PR TITLE
build: update pyinstaller and dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout ${{ env.PROJECT_NAME}}
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # History of 100 should be more than enough to calculate commit count since last release tag.
           fetch-depth: 100
@@ -70,7 +70,7 @@ jobs:
 
   container:
     name: Create Docker image
-    if: "contains(github.ref, 'tags/v')" # only publish for releases!
+    if: github.ref == 'refs/heads/main' || contains(github.ref, 'tags/v')
     runs-on: ubuntu-24.04
     needs: release
 
@@ -125,7 +125,7 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             VERSION=${{ env.IMG_VERSION }}
             REVISION=${{ env.GITHUB_SHA }}
-          platforms: aarch64
+          platforms: linux/arm64/v8
           tags: ${{ env.IMAGE_TAGS }}
 
       - name: Build local Docker image (test mode)
@@ -138,5 +138,5 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             VERSION=${{ env.IMG_VERSION }}
             REVISION=${{ env.GITHUB_SHA }}
-          platforms: aarch64
+          platforms: linux/arm64/v8
           tags: ${{ env.IMAGE_TAGS }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes for the next release will be listed here_
 
+### Changed
+- Update pre-installed Python libraries.
+
 ---
 
 ## 0.4.0 - 2025-09-17

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PYTHON_VERSION=3.11.13
-FROM arm64v8/python:${PYTHON_VERSION}-bullseye
+FROM python:${PYTHON_VERSION}-bullseye
 
 VOLUME /workspace
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 ```shell
 docker run --rm -it \
-  --platform=aarch64 \
+  --platform=linux/arm64/v8 \
   --user=$(id -u):$(id -g) \  
   -v ~/my-project-folder:/workspace \
   docker.io/unfoldedcircle/r2-pyinstaller:3.11.13 bash

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,6 @@ BUILD_LABELS="\
 --build-arg VERSION=${VERSION} \
 --build-arg REVISION=$(git log -1 --format="%H")"
 
-docker build --platform=aarch64 --progress plain $VERSION_ARGS $BUILD_LABELS \
+docker build --platform=linux/arm64/v8 --progress plain $VERSION_ARGS $BUILD_LABELS \
     -t unfoldedcircle/r2-pyinstaller:$PYTHON_VERSION \
     -t unfoldedcircle/r2-pyinstaller:$PYTHON_VERSION-$VERSION .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,19 @@
-pyinstaller~=6.16.0
+pyinstaller~=6.19.0
 
 # Common dependencies of our Python integrations.
 # Pre-installing them in the builder image allows much faster builds on amd64
 # machines with qemu arm64 emulation. This saves up to 20 min of build times!
-pyee~=13.0
-websockets~=15.0
+pyee~=13.0.1
+websockets~=16.0
 zeroconf~=0.147
 
 # Integration specific libraries. PyInstaller only includes required libraries.
 # Android TV integration
-androidtvremote2~=0.2.1
-google_play_scraper~=1.2
-pillow~=11.2
-requests~=2.32
-pychromecast~=14.0
+androidtvremote2~=0.3.0
+google_play_scraper~=1.2.7
+pillow~=12.1.1
+requests~=2.32.5
+pychromecast~=14.0.9
 
 # Apple TV integration
-pyatv~=0.16
-
-# Denon AVR integration
-denonavr~=1.1
+pyatv~=0.17.0


### PR DESCRIPTION
- update pyinstaller to 6.19.0
- update libraries
- denonavr is no longer required, a forked Git reference is used in the Denon integration.

Update Docker image build:
- Platform changed to linux/arm64/v8
- Also build Docker image when pushed to main
- Update Github action version