### PR TITLE
ci: set persist-credentials: false on checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout ${{ env.PROJECT_NAME}}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           # History of 100 should be more than enough to calculate commit count since last release tag.
           fetch-depth: 100
           path: ${{ env.PROJECT_NAME}}


### PR DESCRIPTION
Sets `persist-credentials: false` on the checkout step in the release job. No git push/commit happens in this job — tag fetch/describe is read-only and the release steps use `GH_TOKEN` explicitly via the `gh` CLI, so the persisted git credential isn't needed.

Actions were already pinned to full commit SHAs with version comments, and `.github/dependabot.yml` already has a 14-day cooldown — no changes needed there.